### PR TITLE
Drupal matcher improvements

### DIFF
--- a/src/WappMatchers/DrupalMatcher.php
+++ b/src/WappMatchers/DrupalMatcher.php
@@ -13,12 +13,12 @@ class DrupalMatcher implements WappMatcherInterface
      */
     private const VERSIONS = [
         [
-            'file' => '/modules/system/system.info',
+            'file' => 'modules/system/system.info',
             'regex' => "/version\\s*=\\s*\"(\\d\\.[^']+)\"[\\s\\S]*project\\s*=\\s*\"drupal\"/",
         ],
         [
-            'file' => '/core/modules/system/system.info.yml',
-            'regex' => "/version:\\s*'(\\d\\.[^']+)'[\\s\\S]*project:\\s*'drupal'/",
+            'file' => 'core/modules/system/system.info.yml',
+            'regex' => "/version:\\s*'(\\d+\\.[^']+)'[\\s\\S]*project:\\s*'drupal'/",
         ],
     ];
 
@@ -35,19 +35,21 @@ class DrupalMatcher implements WappMatcherInterface
                 continue;
             }
 
-            preg_match($version['regex'], $fs->read($versionFile), $matches);
-
-            if (!count($matches)) {
-                continue;
-            }
-
+            $version = $this->detectVersion($version['regex'], $versionFile, $fs);
             return [
                 'matcher' => Matchers::DRUPAL,
-                'version' => $matches[1],
+                'version' => $version,
                 'path' => $path,
             ];
         }
 
         return [];
+    }
+
+    private function detectVersion(string $regexPattern, string $versionFile, Filesystem $fs): ?string
+    {
+        preg_match($regexPattern, $fs->read($versionFile), $matches);
+
+        return count($matches) ? $matches[1] : null;
     }
 }

--- a/test-data/drupal/drupal10/core/modules/system/system.info.yml
+++ b/test-data/drupal/drupal10/core/modules/system/system.info.yml
@@ -1,0 +1,12 @@
+name: System
+type: module
+description: 'Provides user interfaces for core systems.'
+package: Core
+# version: VERSION
+required: true
+configure: system.admin_config_system
+
+# Information added by Drupal.org packaging script on 2023-07-06
+version: '10.1.1'
+project: 'drupal'
+datestamp: 1688633026

--- a/test-data/drupal/drupal9/core/modules/system/system.info.yml
+++ b/test-data/drupal/drupal9/core/modules/system/system.info.yml
@@ -1,0 +1,12 @@
+name: System
+type: module
+description: 'Handles general site configuration for administrators.'
+package: Core
+# version: VERSION
+required: true
+configure: system.admin_config_system
+
+# Information added by Drupal.org packaging script on 2023-07-05
+version: '9.5.10'
+project: 'drupal'
+datestamp: 1688551056


### PR DESCRIPTION
* Fix regex for Drupal versions > 9
* Allow matcher to detect Drupal even if no version info was found