### PR TITLE
skip parent dir in `UpLevelMatcherTrait` if that dir is inaccessible

### DIFF
--- a/src/WappMatchers/UpLevelMatcherTrait.php
+++ b/src/WappMatchers/UpLevelMatcherTrait.php
@@ -4,6 +4,7 @@ namespace Plesk\Wappspector\WappMatchers;
 
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemException;
+use League\Flysystem\UnableToListContents;
 
 trait UpLevelMatcherTrait
 {
@@ -15,7 +16,11 @@ trait UpLevelMatcherTrait
     public function match(Filesystem $fs, string $path): array
     {
         if (!$result = $this->doMatch($fs, $path)) {
-            return $this->doMatch($fs, rtrim($path) . '/../');
+            try {
+                $result = $this->doMatch($fs, rtrim($path) . '/../');
+            } catch (UnableToListContents $e) {
+                // skip parent dir if it is inaccessible
+            }
         }
 
         return $result;


### PR DESCRIPTION
`UpLevelMatcherTrait` tries to scan parent dir if no files was found in actually passed dir. But that dir can be inaccessible for user. So `UnableToListContents` is thrown for dir which was not even the one user asked to scan.