### PR TITLE
update WP 4.0 version to fix wiz.io CVE check

### DIFF
--- a/test-data/wordpress/wordpress4.0/wp-includes/version.php
+++ b/test-data/wordpress/wordpress4.0/wp-includes/version.php
@@ -4,7 +4,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '4.0';
+$wp_version = '4.9.25';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.

--- a/tests/Matchers/WordpressTest.php
+++ b/tests/Matchers/WordpressTest.php
@@ -32,7 +32,7 @@ class WordpressTest extends AbstractMatcherTestCase
             ['wordpress/wordpress2.2', '2.2.1'],
             ['wordpress/wordpress2.9', '2.9'],
             ['wordpress/wordpress3.7', '3.7.5'],
-            ['wordpress/wordpress4.0', '4.0'],
+            ['wordpress/wordpress4.0', '4.9.25'],
         ];
     }
 


### PR DESCRIPTION
clients complaining about false-positives of wiz.io checker on wappspector test-data files

https://talk.plesk.com/threads/removing-wappspector.373736/

replaced WP version with a latest one